### PR TITLE
Configure node dbl click modal

### DIFF
--- a/src/lib/classes/NetworkManager.ts
+++ b/src/lib/classes/NetworkManager.ts
@@ -40,7 +40,10 @@ export class NetworkStore implements Writable<NetworkState> {
 		const node = this.getNode(nodeId);
 
 		if (node) {
-			this._nodes = this._nodes.filter((n) => n.id !== nodeId);
+			this._nodes.splice(nodeId, 1);
+			this._connections = this._connections.filter(
+				(c) => c.source.id !== nodeId && c.target.id !== nodeId,
+			);
 			this.nodeMap.delete(nodeId);
 		}
 

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -2,7 +2,7 @@
 	export let dialog: HTMLDialogElement;
 </script>
 
-<dialog bind:this={dialog}>
+<dialog bind:this={dialog} on:close>
 	<slot />
 </dialog>
 

--- a/src/lib/components/HelpButton.svelte
+++ b/src/lib/components/HelpButton.svelte
@@ -15,6 +15,7 @@
 <Dialog bind:dialog>
 	<p>Drag and drop nodes that you want to add.</p>
 	<p>Hold the shift key and drag nodes to make connections between the nodes.</p>
+	<p>Double press a node to configure/delete it.</p>
 	<p>Press Esc to close this popup.</p>
 </Dialog>
 

--- a/src/lib/components/HelpButton.svelte
+++ b/src/lib/components/HelpButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Dialog from "$lib/components/Modal.svelte";
+	import Dialog from "$lib/components/Dialog.svelte";
 
 	let dialog: HTMLDialogElement;
 </script>

--- a/src/lib/components/NodeSettings.svelte
+++ b/src/lib/components/NodeSettings.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { network } from "$lib/stores/network";
+	import type { Node } from "$lib/interfaces/network";
+	import Dialog from "$lib/components/Dialog.svelte";
+
+	export let node: Node | null;
+	export let dialog: HTMLDialogElement;
+
+	function handleClick(event: MouseEvent) {
+		if (node && confirm("Are you sure you want to delete this node?")) {
+			network.deleteNode(node.id);
+			dialog.close();
+		}
+	}
+</script>
+
+<Dialog
+	bind:dialog
+	on:close={() => {
+		network.fastUpdate();
+	}}
+>
+	{#if node}
+		<label>
+			Label:
+			<input type="text" bind:value={node.label} />
+		</label>
+
+		<p>ID: {node.id}</p>
+		<p>Type: {node.type}</p>
+		<p>Position: {node.x.toFixed(2)}, {node.y.toFixed(2)}</p>
+		<button on:click={handleClick}>Delete Node</button>
+	{:else}
+		<p>You somehow double-clicked on a node that can't be found?</p>
+	{/if}
+</Dialog>

--- a/src/lib/components/NodeSettings.svelte
+++ b/src/lib/components/NodeSettings.svelte
@@ -6,7 +6,7 @@
 	export let node: Node | null;
 	export let dialog: HTMLDialogElement;
 
-	function handleClick(event: MouseEvent) {
+	function handleClick() {
 		if (node && confirm("Are you sure you want to delete this node?")) {
 			network.deleteNode(node.id);
 			dialog.close();


### PR DESCRIPTION
smol change in NetworkManager to splice instead of filter and also remove connections when a node is deleted, otherwise we are left with floating lines D:
add back the on:close event for dialog, whoops, and rename from modal to dialog now that Windows isn't dumb to us
make node settings that open a dialog on double click, I would have liked to use event.target but it keeps giving me the SVG box instead of a child element like circle as it does in pointer down event

Closes #22 

It still needs styling, etc., and maybe we should not use confirm(), but implement a custom confirm box, etc., but these are global things and not specific to this issue