### PR TITLE
same format as paper + simplify/fix

### DIFF
--- a/src/lib/classes/MPLS/Packet.ts
+++ b/src/lib/classes/MPLS/Packet.ts
@@ -53,13 +53,10 @@ export default class Packet {
   }
 
   validateNextHop(currentRouter: Router): boolean {
-    if (
+    return (
       network.doesLinkExist({ source: currentRouter, target: this.nextHop }) ||
       network.doesLinkExist({ source: this.nextHop, target: currentRouter })
-    ) {
-      return true;
-    }
-    return false;
+    );
   }
 
   setFallbackNextHop() {


### PR DESCRIPTION
looks better in the paper this way + fixes extra console.warn()s

when animation finishes, next router receives packet
if nexthop didn't change, then either 1) ce received packet or 2) fallback didn't change nexthop (must be disabled or not required), therefore we just return and assume that 1) ce dropped the packet or 2) fallback dropped the packet. then we validate the link, if not valid, drop packet with the reason. finally, animate